### PR TITLE
Lock toolchain on 1.53, update default config file

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -40,8 +40,8 @@ struct CoordinatorTomlConfiguration {
     /// TODO: refactor later to use a proper address type
     listen_address: SocketAddr,
 
-    /// TODO: is this actually in use??
-    database_address: SocketAddr,
+    /// Path to the SQLite db
+    sqlite_file: PathBuf,
 
     /// Settings related to reliability checks
     pub reliability_check: ReliabilityCheckSettings,
@@ -95,7 +95,7 @@ impl From<&CoordinatorConfig> for CoordinatorTomlConfiguration {
             setup: config.environment,
             replacement_contributors,
             listen_address: SocketAddr::from_str("0.0.0.0:9000").unwrap(),
-            database_address: SocketAddr::from_str("127.0.0.1:2000").unwrap(),
+            sqlite_file: "setup.db3".into(),
             reliability_check: ReliabilityCheckSettings {
                 // TODO: update this when reliability checks are implemented.
                 is_enabled: false,

--- a/src/test.rs
+++ b/src/test.rs
@@ -291,7 +291,7 @@ pub fn integration_test(
     let keys_dir_path = create_dir_if_not_exists(options.out_dir.join("keys"))?;
 
     // Unfortunately aleo-setup still requires an old version of nightly to compile.
-    let rust_1_48 = RustToolchain::Specific("1.48".to_string());
+    let rust_1_53 = RustToolchain::Specific("1.53".to_string());
 
     // Attempt to clone the git repos if they don't already exist.
     clone_git_repos(&options)?;
@@ -311,25 +311,25 @@ pub fn integration_test(
     if options.install_prerequisites {
         // Install a specific version of the rust toolchain needed to be
         // able to compile `aleo-setup`.
-        install_rust_toolchain(&rust_1_48)
-            .wrap_err_with(|| eyre::eyre!("error while installing rust toolchain {}", rust_1_48))?;
+        install_rust_toolchain(&rust_1_53)
+            .wrap_err_with(|| eyre::eyre!("error while installing rust toolchain {}", rust_1_53))?;
     }
 
     if options.build {
         // Build the setup coordinator Rust project.
-        build_rust_crate(coordinator_dir, &rust_1_48)
+        build_rust_crate(coordinator_dir, &rust_1_53)
             .wrap_err("error while building aleo-setup-coordinator crate")?;
 
         // Build the setup1-contributor Rust project.
-        build_rust_crate(setup_dir.join("setup1-contributor"), &rust_1_48)
+        build_rust_crate(setup_dir.join("setup1-contributor"), &rust_1_53)
             .wrap_err("error while building setup1-contributor crate")?;
 
         // Build the setup1-verifier Rust project.
-        build_rust_crate(setup_dir.join("setup1-verifier"), &rust_1_48)
+        build_rust_crate(setup_dir.join("setup1-verifier"), &rust_1_53)
             .wrap_err("error while building setup1-verifier crate")?;
 
         // Build the setup1-cli-tools Rust project.
-        build_rust_crate(setup_dir.join("setup1-cli-tools"), &rust_1_48)
+        build_rust_crate(setup_dir.join("setup1-cli-tools"), &rust_1_53)
             .wrap_err("error while building setup1-verifier crate")?;
 
         // Build the aleo-setup-state-monitor Rust project.


### PR DESCRIPTION
The default config file did not include a path to
a SQLite db, which made it panic on startup. Furthermore, the locked toolchain
on 1.48 caused compilation errors, which prevent the running of tests.